### PR TITLE
Webpack config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  presets: ['react', 'es2015'],
+  env: {
+    production: {
+      plugins: [
+        'ramda',
+      ],
+    },
+  },
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+build

--- a/bin/server.entry.js
+++ b/bin/server.entry.js
@@ -1,0 +1,5 @@
+// this .entry.js file simply enables ES6 language features
+
+require('babel-register');
+
+module.exports = require(require('path').resolve(__dirname, 'server'));

--- a/bin/server.entry.js
+++ b/bin/server.entry.js
@@ -1,3 +1,5 @@
+#! /usr/bin/env node
+
 // this .entry.js file simply enables ES6 language features
 
 require('babel-register');

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,0 +1,7 @@
+import 'babel-polyfill';
+
+import { server } from 'universal-webpack';
+import settings from '../setup/universal-webpack-settings';
+import configuration from '../setup/webpack.config';
+
+server(configuration, settings);

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "music",
   "version": "0.0.1",
   "description": "Simple music player/server",
-  "main": "packages/server/index.js",
+  "main": "bin/server.js",
   "scripts": {
     "build": "webpack build --config=./setup/webpack.config.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "npm-run-all prepare:dev start:dev",
+    "prepare:dev": "universal-webpack --settings './setup/universal-webpack-settings.js' prepare",
+    "server:dev": "NODE_ENV=dev nodemon './bin/server.entry.js' --watch './build/server'",
+    "start:dev": "npm-run-all --parallel wds watch server:dev",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "watch": "webpack --watch --config './setup/webpack.config.server.entry.js' --colors --display-error-details",
+    "wds": "webpack-dev-server --hot --inline --config './setup/webpack.config.client.entry.js' --port 3001 --colors --display-error-details"
   },
   "repository": {
     "type": "git",
@@ -24,10 +30,13 @@
   "dependencies": {
     "babel-polyfill": "^6.9.1",
     "classnames": "^2.2.5",
+    "extract-text-webpack-plugin": "^1.0.1",
     "isomorphic-fetch": "^2.2.1",
     "koa": "^1.2.0",
     "koa-mount": "^1.3.0",
     "koa-static": "^2.0.0",
+    "nodemon": "^1.10.2",
+    "npm-run-all": "^3.1.0",
     "ramda": "^0.21.0",
     "react": "^15.2.1",
     "react-helmet": "^3.1.0",
@@ -40,8 +49,8 @@
     "serialize-javascript": "^1.3.0",
     "sqlite3": "^3.1.4",
     "umzug": "^1.11.0",
-    "use-named-routes": "^0.3.1",
-    "webpack-isomorphic-tools": "^2.3.2"
+    "universal-webpack": "^0.1.39",
+    "use-named-routes": "^0.3.1"
   },
   "devDependencies": {
     "babel": "^6.5.2",
@@ -49,15 +58,18 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-ramda": "^1.1.6",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.11.1",
     "chai": "^3.5.0",
     "eslint": "^3.0.1",
     "flow-bin": "^0.29.0",
+    "koa-proxy": "^0.6.0",
     "mocha": "^2.5.3",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
     "stylelint": "^7.0.2",
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.1",
+    "webpack-dev-server": "^1.15.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple music player/server",
   "main": "packages/server/index.js",
   "scripts": {
+    "build": "webpack build --config=./setup/webpack.config.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -25,6 +26,8 @@
     "classnames": "^2.2.5",
     "isomorphic-fetch": "^2.2.1",
     "koa": "^1.2.0",
+    "koa-mount": "^1.3.0",
+    "koa-static": "^2.0.0",
     "ramda": "^0.21.0",
     "react": "^15.2.1",
     "react-helmet": "^3.1.0",
@@ -44,12 +47,16 @@
     "babel": "^6.5.2",
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
+    "babel-plugin-ramda": "^1.1.6",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-react": "^6.11.1",
     "chai": "^3.5.0",
     "eslint": "^3.0.1",
     "flow-bin": "^0.29.0",
     "mocha": "^2.5.3",
+    "react": "^15.3.1",
+    "react-dom": "^15.3.1",
     "stylelint": "^7.0.2",
     "webpack": "^1.13.1"
   }

--- a/package.json
+++ b/package.json
@@ -4,14 +4,19 @@
   "description": "Simple music player/server",
   "main": "bin/server.js",
   "scripts": {
-    "build": "webpack build --config=./setup/webpack.config.js",
-    "dev": "npm-run-all prepare:dev start:dev",
+    "build": "npm-run-all --parallel build:client build:server",
+    "build:client": "webpack --config './setup/webpack.config.client.entry.js' --colors --display-error-details",
+    "build:server": "webpack --config './setup/webpack.config.server.entry.js' --colors --display-error-details",
     "prepare:dev": "universal-webpack --settings './setup/universal-webpack-settings.js' prepare",
     "server:dev": "NODE_ENV=dev nodemon './bin/server.entry.js' --watch './build/server'",
+    "server:prod": "NODE_ENV=prod ./bin/server.entry.js",
     "start:dev": "npm-run-all --parallel wds watch server:dev",
     "test": "echo \"Error: no test specified\" && exit 1",
     "watch": "webpack --watch --config './setup/webpack.config.server.entry.js' --colors --display-error-details",
-    "wds": "webpack-dev-server --hot --inline --config './setup/webpack.config.client.entry.js' --port 3001 --colors --display-error-details"
+    "wds": "webpack-dev-server --hot --inline --config './setup/webpack.config.client.entry.js' --port 3001 --colors --display-error-details",
+
+    "dev": "npm-run-all prepare:dev start:dev",
+    "prod": "npm-run-all build server:prod"
   },
   "repository": {
     "type": "git",

--- a/packages/data/modules/test.js
+++ b/packages/data/modules/test.js
@@ -1,0 +1,3 @@
+export default function(state = {}, action) {
+  return state;
+}

--- a/packages/data/reducer.js
+++ b/packages/data/reducer.js
@@ -1,5 +1,7 @@
 import { combineReducers } from 'redux';
 
-export default combineReducers({
+import test from './modules/test';
 
+export default combineReducers({
+  test,
 });

--- a/packages/routes/app.js
+++ b/packages/routes/app.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function({ children }) {
+  return <div>{children}</div>;
+}

--- a/packages/routes/home/home.js
+++ b/packages/routes/home/home.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function() {
+  return <div>Welcome home!</div>
+}

--- a/packages/routes/routes.js
+++ b/packages/routes/routes.js
@@ -6,8 +6,8 @@ import Home from './home/home';
 
 export default function getRoutes() {
   return (
-    <IndexRoute component={App}>
+    <Route path="/" component={App}>
       <IndexRoute name="home" component={Home} />
-    </IndexRoute>
+    </Route>
   );
 }

--- a/packages/routes/routes.js
+++ b/packages/routes/routes.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { IndexRoute, Route } from 'react-router';
 
 import App from './app';

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -1,13 +1,18 @@
 import 'babel-polyfill';
 import 'isomorphic-fetch';
 import koa from 'koa';
+import mount from 'koa-mount';
+import static from 'koa-static';
+import path from 'path';
 
 import Handler from './server-html';
 
 const PORT = (+process.env.PORT) || 3000;
+const REPO_ROOT = path.resolve(__dirname, '../../');
 
 const app = koa();
 
+app.use(mount('/assets', static(path.join(REPO_ROOT, 'build'))))
 app.use(Handler);
 
 app.listen(PORT);

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -2,17 +2,37 @@ import 'babel-polyfill';
 import 'isomorphic-fetch';
 import koa from 'koa';
 import mount from 'koa-mount';
-import static from 'koa-static';
+import StaticHandler from 'koa-static';
 import path from 'path';
 
 import Handler from './server-html';
 
 const PORT = (+process.env.PORT) || 3000;
 const REPO_ROOT = path.resolve(__dirname, '../../');
+const DEV = process.env.NODE_ENV === 'dev';
+const WDS_PORT = DEV ? (PORT + 1) : null;
+const WDS_HOST = DEV ? (process.env.HOST || 'localhost') : null;
 
-const app = koa();
+export default function(params) {
 
-app.use(mount('/assets', static(path.join(REPO_ROOT, 'build'))))
-app.use(Handler);
+  const app = koa();
 
-app.listen(PORT);
+  // static assets (built by webpack)
+  if (DEV) {
+    const proxy = require('koa-proxy');
+
+    // proxy to the webpack dev server when in dev mode
+    app.use(proxy({
+      host: `http://${WDS_HOST}:${WDS_PORT}`,
+      match: /^\/assets\//,
+    }));
+  } else {
+    app.use(mount('/assets', StaticHandler(path.join(REPO_ROOT, 'build'))));
+  }
+
+  // React handler
+  app.use(Handler(params));
+
+  console.log('LISTENING ON PORT', PORT);
+  app.listen(PORT);
+}

--- a/setup/universal-webpack-settings.js
+++ b/setup/universal-webpack-settings.js
@@ -1,0 +1,8 @@
+require('babel-register');
+
+module.exports = {
+  server: {
+    input: './packages/server/index.js',
+    output: './build/server/server.js',
+  },
+};

--- a/setup/webpack-isomorphic-tools.js
+++ b/setup/webpack-isomorphic-tools.js
@@ -1,0 +1,74 @@
+const WebpackIsomorphicToolsPlugin = require('webpack-isomorphic-tools/plugin');
+
+// Details on configuration here:
+// https://github.com/halt-hammerzeit/webpack-isomorphic-tools
+module.exports = {
+
+  // Enable debug mode for more verbose output.
+  // debug: true,
+
+  assets: {
+    images: {
+      extensions: [
+        'jpeg',
+        'jpg',
+        'png',
+        'gif',
+      ],
+      parser: WebpackIsomorphicToolsPlugin.url_loader_parser,
+    },
+    fonts: {
+      extensions: [
+        'woff',
+        'woff2',
+        'ttf',
+        'eot',
+      ],
+      parser: WebpackIsomorphicToolsPlugin.url_loader_parser,
+    },
+    svg: {
+      extension: 'svg',
+      parser: WebpackIsomorphicToolsPlugin.url_loader_parser,
+    },
+    style_modules: {
+      extensions: ['css'],
+      filter: (module, regex, options, log) => {
+        if (options.development) {
+          // in development mode there's webpack "style-loader",
+          // so the module.name is not equal to module.name
+          return WebpackIsomorphicToolsPlugin.style_loader_filter(
+            module, regex, options, log
+          );
+        } else {
+          // in production mode there's no webpack "style-loader",
+          // so the module.name will be equal to the asset path
+          return regex.test(module.name);
+        }
+      },
+      path: (module, options, log) => {
+        if (options.development) {
+          // in development mode there's webpack "style-loader",
+          // so the module.name is not equal to module.name
+          return WebpackIsomorphicToolsPlugin.style_loader_path_extractor(
+            module, options, log
+          );
+        } else {
+          // in production mode there's no webpack "style-loader",
+          // so the module.name will be equal to the asset path
+          return module.name;
+        }
+      },
+      parser: (module, options, log) => {
+        if (options.development) {
+          return WebpackIsomorphicToolsPlugin.css_modules_loader_parser(
+            module, options, log
+          );
+        } else {
+          // in production mode there's Extract Text Loader which extracts
+          // CSS text away
+          return module.source;
+        }
+      },
+    },
+  },
+};

--- a/setup/webpack.config.client.entry.js
+++ b/setup/webpack.config.client.entry.js
@@ -1,0 +1,5 @@
+// this .entry.js file simply enables ES6 language features
+
+require('babel-register');
+
+module.exports = require(require('path').resolve(__dirname, 'webpack.config.client'));

--- a/setup/webpack.config.client.js
+++ b/setup/webpack.config.client.js
@@ -1,0 +1,5 @@
+import { client_configuration } from 'universal-webpack';
+import settings from './universal-webpack-settings';
+import config from './webpack.config';
+
+export default client_configuration(config, settings);

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -1,0 +1,42 @@
+path = require('path');
+
+const REPO_ROOT = path.resolve(
+  __dirname,
+  '..'
+);
+
+module.exports = {
+  context: REPO_ROOT,
+  entry: './packages/server/client.js',
+  output: {
+    path: REPO_ROOT + '/build',
+    publicPath: '/assets/',
+  },
+
+  resolve: {
+    // Behaves similar to process.env.NODE_PATH
+    modulesDirectories: [
+      'packages',
+      'node_modules',
+    ],
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel',
+        query: {
+          presets: ['react', 'es2015'],
+          env: {
+            production: {
+              plugins: [
+                'ramda',
+              ],
+            },
+          },
+        },
+      },
+    ],
+  },
+};

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -1,24 +1,35 @@
-path = require('path');
+const path = require('path');
+const fs = require('fs');
 
 const REPO_ROOT = path.resolve(
   __dirname,
   '..'
 );
 
+const packageDirs = fs.readdirSync(path.join(REPO_ROOT, 'packages'))
+  .filter(dir =>
+    fs.statSync(path.join(REPO_ROOT, 'packages', dir)).isDirectory()
+  );
+
+const alias = packageDirs.reduce((obj, p) => {
+  obj[p] = path.join(REPO_ROOT, 'packages', p);
+  return obj;
+}, {});
+
 module.exports = {
   context: REPO_ROOT,
-  entry: './packages/server/client.js',
+  entry: [
+    'babel-polyfill',
+    './packages/server/client.js',
+  ],
   output: {
+    filename: '[name]-[chunkhash].js',
     path: REPO_ROOT + '/build',
     publicPath: '/assets/',
   },
 
   resolve: {
-    // Behaves similar to process.env.NODE_PATH
-    modulesDirectories: [
-      'packages',
-      'node_modules',
-    ],
+    alias,
   },
   module: {
     loaders: [
@@ -26,16 +37,13 @@ module.exports = {
         test: /\.js$/,
         exclude: /node_modules/,
         loader: 'babel',
-        query: {
-          presets: ['react', 'es2015'],
-          env: {
-            production: {
-              plugins: [
-                'ramda',
-              ],
-            },
-          },
-        },
+      },
+      {
+        test: /\.css$/,
+        loaders: [
+          'style',
+          'css?modules&localIdentName=[name]__[local]___[hash:base64:5]',
+        ],
       },
     ],
   },

--- a/setup/webpack.config.js
+++ b/setup/webpack.config.js
@@ -27,6 +27,11 @@ module.exports = {
     path: REPO_ROOT + '/build',
     publicPath: '/assets/',
   },
+  node: {
+    // Disable webpack's overwriting of __dirname
+    // This is needed for serving static assets in prod mode
+    __dirname: false,
+  },
 
   resolve: {
     alias,

--- a/setup/webpack.config.server.entry.js
+++ b/setup/webpack.config.server.entry.js
@@ -1,0 +1,5 @@
+// this .entry.js file simply enables ES6 language features
+
+require('babel-register');
+
+module.exports = require(require('path').resolve(__dirname, 'webpack.config.server'));

--- a/setup/webpack.config.server.js
+++ b/setup/webpack.config.server.js
@@ -1,0 +1,5 @@
+import { server_configuration } from 'universal-webpack';
+import settings from './universal-webpack-settings';
+import config from './webpack.config';
+
+export default server_configuration(config, settings);


### PR DESCRIPTION
Resolves #1 

This was a pain. Next side-project I decide to take on, maybe I don't try to make it isomorphic right from the start. Or who knows, maybe now that I've done it once it'll be easy. Regardless, it works! It's building and rendering, both in dev mode using `webpack-dev-server` and hot reloading, and in prod mode with static assets just being built once.

To launch the dev server at `localhost:3000`: `npm run dev`
To build and then launch the prod server at `localhost:3000`: `npm run prod`

I half-supported a `PORT` env variable, but the webpack dev server isn't respecting that variable at the moment. Maybe someday I'll poke around and figure out the right way to do a default variable in an npm script.
